### PR TITLE
Effectively use merge_at

### DIFF
--- a/aicoe/sesheta/actions/pull_request.py
+++ b/aicoe/sesheta/actions/pull_request.py
@@ -113,7 +113,7 @@ async def needs_size_label(_pull_request: dict = None) -> bool:
         except gidgethub.BadRequest as err:
             if err.status_code != 202:
                 _LOGGER.error(str(err))
-    elif needs_size_actual and has_size_label:
+    elif needs_size_actual and has_size_label != size_label:
         _LOGGER.debug(f"removing pervious size label '{has_size_label}' from {pull_request['html_url']}")
 
         try:
@@ -168,7 +168,7 @@ async def needs_rebase_label(_pull_request: dict = None) -> bool:
 
     _LOGGER.debug(f"checking if {pull_request['html_url']} needs a rebase label")
 
-    needs_rebase_actual = await is_mergeable(pull_request)
+    needs_rebase_actual = await is_rebaseable(pull_request)
     has_rebase_label = has_label(pull_request, "do-not-merge/needs-rebase")
 
     if needs_rebase_actual and not has_rebase_label:
@@ -333,8 +333,8 @@ async def local_check_gate_passed(pr_url: str) -> bool:
     return False
 
 
-async def is_mergeable(pull_request: dict = None) -> bool:
-    """Determine if the Pull Request is mergeable."""
+async def is_rebaseable(pull_request: dict = None) -> bool:
+    """Determine if the Pull Request is rebaseable."""
     if pull_request["merged"]:
         return False
 
@@ -342,6 +342,14 @@ async def is_mergeable(pull_request: dict = None) -> bool:
         return True
 
     return False
+
+
+async def is_mergeable(pull_request: dict = None) -> bool:
+    """Determine if the Pull Request is mergeable."""
+    if pull_request["merged_at"]:
+        return False
+    else:
+        return True
 
 
 def has_label(pull_request: dict, label: str) -> bool:

--- a/tests/needs_rebase_test.py
+++ b/tests/needs_rebase_test.py
@@ -21,7 +21,7 @@
 import json
 import pytest
 
-from aicoe.sesheta.actions.pull_request import has_label, is_mergeable
+from aicoe.sesheta.actions.pull_request import has_label, is_rebaseable
 
 
 @pytest.fixture
@@ -48,8 +48,8 @@ class TestNeedsRebase:
         assert pr_needs_rebase is not None
         assert has_needs_rebase_label is not None
 
-        has_needs_rebase_label_actual = await is_mergeable(has_needs_rebase_label)
-        pr_needs_rebase_actual = await is_mergeable(pr_needs_rebase)
+        has_needs_rebase_label_actual = await is_rebaseable(has_needs_rebase_label)
+        pr_needs_rebase_actual = await is_rebaseable(pr_needs_rebase)
 
         assert has_needs_rebase_label_actual == False
         assert pr_needs_rebase_actual == False
@@ -58,6 +58,6 @@ class TestNeedsRebase:
     async def test_pull_request_doesnt_need_rebase(self, doesnt_need_rebase):
         assert doesnt_need_rebase is not None
 
-        doesnt_need_rebase_actual = await is_mergeable(doesnt_need_rebase)
+        doesnt_need_rebase_actual = await is_rebaseable(doesnt_need_rebase)
 
         assert not doesnt_need_rebase_actual


### PR DESCRIPTION
The key `merged` and `mergeable` are exclusive to open and edit of PR. 
As `mergeable` is used to check if PR can be merged to master, we can use the `merge_at` key to check if PR has been merged, for not labeling merged PRs.

- Made changes in the name
- condition to check for similar size tag 

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>