### PR TITLE
Respect Null response of github api attrib

### DIFF
--- a/aicoe/sesheta/actions/pull_request.py
+++ b/aicoe/sesheta/actions/pull_request.py
@@ -337,7 +337,7 @@ async def is_rebaseable(pull_request: dict = None) -> bool:
     if pull_request["merged"]:
         return False
 
-    if not pull_request["mergeable"]:
+    if not pull_request["mergeable"] and pull_request["mergeable"] is not None:
         return True
 
     return False


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

`do-not-merge/needs-rebase` label is being added on PR which doesn't need rebasing.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

check for only false not for false and null.

## Description

As github API's value of the mergeable attribute can be true, false, or null. 
null, is added when GitHub has started a background job to compute the mergeability.
doesn't mean conclusion is that rebase is needed.

