### PR TITLE
use the whole branch name for tag

### DIFF
--- a/aicoe/sesheta/actions/pull_request.py
+++ b/aicoe/sesheta/actions/pull_request.py
@@ -404,13 +404,12 @@ async def handle_release_pull_request(pullrequest: dict) -> (str, str):
 
     commit_hash = pullrequest["merge_commit_sha"]
     release_issue = get_release_issue(pullrequest)
-    # TODO this could use a try-except
-    release = pullrequest["head"]["ref"][1:]
+    release = pullrequest["head"]["ref"]
 
     # tag
     _LOGGER.info(f"Tagging release {release}: hash {commit_hash}.")
 
-    tag = {"tag": f"v{release}", "message": f"v{release}\n", "object": str(commit_hash), "type": "commit"}
+    tag = {"tag": str(release), "message": str(release), "object": str(commit_hash), "type": "commit"}
     response = await github_api.post(
         f"{pullrequest['base']['repo']['url']}/git/tags", preview_api_version="lydian", data=tag,
     )


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Include the prefix **v** for tags 

PR: https://github.com/AICoE/Sefkhet-Abwy/pull/27
Issue: https://github.com/thoth-station/kebechet/issues/374

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

The line https://github.com/AICoE/Sefkhet-Abwy/blob/c2014f190c951951e7f2cf1af6e67c8a18895d91/aicoe/sesheta/actions/pull_request.py#L408 used to exclude the prefix **v**, however, the pr https://github.com/AICoE/Sefkhet-Abwy/pull/27 the prefix **v** was explicitly been added to the tag name while creating the tag object. 
The tags are created when reference is set, line https://github.com/AICoE/Sefkhet-Abwy/blob/c2014f190c951951e7f2cf1af6e67c8a18895d91/aicoe/sesheta/actions/pull_request.py#L422, as this was missing the prefix **v**, tags were not being created with the proper tag name.

The fix in this PR uses the branch ref directly which is already been set in expression vX.Y.Z by kebechet, so this should enforce the **v** prefix.