### PR TITLE
[WIP] removed some of the 'approved' label handling logic

### DIFF
--- a/aicoe/sesheta/review_manager.py
+++ b/aicoe/sesheta/review_manager.py
@@ -204,23 +204,9 @@ async def on_pull_request_review(*, action, review, pull_request, **kwargs):
     """React to Pull Request Review event."""
     _LOGGER.debug(f"on_pull_request_review: working on PR {pull_request['html_url']}")
 
-    notification_text = ""
-    needs_rebase = await needs_rebase_label(pull_request)
-
-    if needs_rebase:
-        await merge_master_into_pullrequest2(
-            pull_request["base"]["user"]["login"], pull_request["base"]["repo"]["name"], pull_request["id"],
-        )
-
-    if review["state"] == "approved":
-        notification_text = f"📗 '{realname(review['user']['login'])}' *approved* this Pull Request!"
-        await needs_approved_label(pull_request)
-    else:
-        notification_text = f"📔 some new comment by '{realname(review['user']['login'])}' has arrived..."
-
     notify_channel(
         "plain",
-        notification_text,
+        f"📔 some new comment by '{realname(review['user']['login'])}' has arrived..."
         f"pull_request_{kwargs['repository']['name']}_{pull_request['id']}",
         pull_request["html_url"],
     )

--- a/tests/conclude_reviewer_list_test.py
+++ b/tests/conclude_reviewer_list_test.py
@@ -23,21 +23,21 @@ import pytest
 from aicoe.sesheta.actions.common import conclude_reviewer_list
 
 
-class TestConcludeReviewers:
+class TestConcludeReviewers:  # noqa: D101
     @pytest.mark.asyncio
-    async def test_conclude_reviewers_no_org(self):
+    async def test_conclude_reviewers_no_org(self):  # noqa: D102
         reviewers = await conclude_reviewer_list(repo="repo")
 
         assert reviewers is None
 
     @pytest.mark.asyncio
-    async def test_conclude_reviewers_no_repo(self):
+    async def test_conclude_reviewers_no_repo(self):  # noqa: D102
         reviewers = await conclude_reviewer_list("org")
 
         assert reviewers is None
 
     @pytest.mark.asyncio
-    async def test_conclude_reviewers_no_codeowners_file(self):
+    async def test_conclude_reviewers_no_codeowners_file(self):  # noqa: D102
         reviewers = await conclude_reviewer_list("thoth-station", "user-api")
 
         assert reviewers is not None
@@ -45,7 +45,7 @@ class TestConcludeReviewers:
         assert reviewers[0] == "fridex"
 
     @pytest.mark.asyncio
-    async def test_conclude_reviewers(self):
+    async def test_conclude_reviewers(self):  # noqa: D102
         reviewers = await conclude_reviewer_list("thoth-station", "storages")
 
         assert reviewers is not None

--- a/tests/has_label_test.py
+++ b/tests/has_label_test.py
@@ -25,26 +25,26 @@ from aicoe.sesheta.actions.pull_request import has_label
 
 
 @pytest.fixture
-def no_work_in_progress_labeled_pull_request():
+def no_work_in_progress_labeled_pull_request():  # noqa: D103
     with open("fixtures/pull_request_148.json") as json_file:
         return json.load(json_file)
 
 
 @pytest.fixture
-def has_work_in_progress_labeled():
+def has_work_in_progress_labeled():  # noqa: D103
     with open("fixtures/pull_request_2.json") as json_file:
         return json.load(json_file)
 
 
-class TestHasLabel:
+class TestHasLabel:  # noqa: D101
     @pytest.mark.asyncio
-    async def test_label_is_not_present(self, no_work_in_progress_labeled_pull_request):
+    async def test_label_is_not_present(self, no_work_in_progress_labeled_pull_request):  # noqa: D102
         assert no_work_in_progress_labeled_pull_request is not None
 
         assert not has_label(no_work_in_progress_labeled_pull_request, "do-not-merge/work-in-progress")
 
     @pytest.mark.asyncio
-    async def test_label_is_present(self, has_work_in_progress_labeled):
+    async def test_label_is_present(self, has_work_in_progress_labeled):  # noqa: D102
         assert has_work_in_progress_labeled is not None
 
         assert has_label(has_work_in_progress_labeled, "do-not-merge/work-in-progress")

--- a/tests/needs_rebase_test.py
+++ b/tests/needs_rebase_test.py
@@ -25,26 +25,26 @@ from aicoe.sesheta.actions.pull_request import has_label, is_rebaseable
 
 
 @pytest.fixture
-def pr_needs_rebase():
+def pr_needs_rebase():  # noqa: D103
     with open("fixtures/pull_request_150.json") as json_file:
         return json.load(json_file)
 
 
 @pytest.fixture
-def has_needs_rebase_label():
+def has_needs_rebase_label():  # noqa: D103
     with open("fixtures/pull_request_148.json") as json_file:
         return json.load(json_file)
 
 
 @pytest.fixture
-def doesnt_need_rebase():
+def doesnt_need_rebase():  # noqa: D103
     with open("fixtures/pull_request_2.json") as json_file:
         return json.load(json_file)
 
 
-class TestNeedsRebase:
+class TestNeedsRebase:  # noqa: D101
     @pytest.mark.asyncio
-    async def test_pull_request_needs_rebase(self, pr_needs_rebase, has_needs_rebase_label):
+    async def test_pull_request_needs_rebase(self, pr_needs_rebase, has_needs_rebase_label):  # noqa: D102
         assert pr_needs_rebase is not None
         assert has_needs_rebase_label is not None
 
@@ -55,7 +55,7 @@ class TestNeedsRebase:
         assert pr_needs_rebase_actual == False
 
     @pytest.mark.asyncio
-    async def test_pull_request_doesnt_need_rebase(self, doesnt_need_rebase):
+    async def test_pull_request_doesnt_need_rebase(self, doesnt_need_rebase):  # noqa: D102
         assert doesnt_need_rebase is not None
 
         doesnt_need_rebase_actual = await is_rebaseable(doesnt_need_rebase)


### PR DESCRIPTION
removed some of the 'approved' label handling logic, so we can leave it to prow to add the label

Signed-off-by: Christoph Görn <goern@redhat.com>

## This introduces a breaking change

- [x] Yes
- [ ] No

## This Pull Request implements

S-A is no longer adding an 'approved' label on an approving PR review. This will break the behaviour we have had before, therefore we need to have prow handle `/approve` comments and enable prow an all repos...
