### PR TITLE
allow sefkhet-abwy to approve sesheta's pr

### DIFF
--- a/aicoe/sesheta/review_manager.py
+++ b/aicoe/sesheta/review_manager.py
@@ -188,6 +188,10 @@ async def on_pr_open_or_edit(*, action, number, pull_request, repository, sender
                     data={"body": "This is an auto-approve of an auto-PR.", "event": "APPROVE"},
                 )
 
+                await github_api.post(
+                    f"{issue_url}/labels", preview_api_version="symmetra", data={"labels": ["approved"]},
+                )
+
             except gidgethub.BadRequest as err:
                 if err.status_code != 202:
                     _LOGGER.error(str(err))


### PR DESCRIPTION
## Related Issues and Dependencies

Automated updates and releases pull request are not merged even after sesheta self approves.
Reason being: as sesheta is not an owner of the application, prow doesn't add an approved labels.

## This introduces a breaking change

- [x] No

## This Pull Request implements

allow sefkhet-abwy to add an approved label to the self-approved sesheta's pr

## Description

allow sefkhet-abwy to approve sesheta's pr

as sesheta opens a pr and self approves it, the approved label isn't added if sesheta is not the owner of the project.
the idea in the pr is to allow sefkhet-abwy to added approved label to those pr's . In this way, cyborg team members wouldn't have to be the owners as well.

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>