### PR TITLE
Update project owners and remove maintainers from thoth config

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -17,10 +17,6 @@ managers:
   - name: info
   - name: version
     configuration:
-      maintainers:
-        - goern
-        - fridex
-        - harshad16
       assignees:
         - sesheta
       labels: [bot]

--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - harshad16
+  - codificat
+  - fridex
   - goern
-  - sesheta
+  - harshad16
 
 reviewers:
+  - codificat
   - fridex
-  - saisankargochhayat
+  - harshad16
 
 labels:
   - sig/user-experience


### PR DESCRIPTION
## Related Issues and Dependencies

Creating this after  #173.

There is work in progress to update a few OWNERS files, including the template project: thoth-station/template-project#24

## This introduces a breaking change

No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Adds the current team to the list of approvers and reviewers in `OWNERS`.

Also, let the bot rely on this file instead of duplicating a maintainers list within `.thoth.yaml`

